### PR TITLE
start/endパラメータを指定しないときのデフォルト値の設定

### DIFF
--- a/api/api/openapi.yml
+++ b/api/api/openapi.yml
@@ -35,14 +35,14 @@ paths:
       parameters:
         - name: start
           in: query
-          required: true
-          description: "絞り込む期間の開始時刻(Unix秒)"
-          schema: {type: string, example: '1711966578'}
+          required: false
+          description: "絞り込む期間の開始時刻(Unix秒)、未指定の場合は現在の日付の午前0時"
+          schema: {type: string, example: '1711966578', default: '1711897200'}
         - name: end
           in: query
-          required: true
-          description: "絞り込む期間の終了時刻(Unix秒)"
-          schema: {type: string, example: '1713176178'}
+          required: false
+          description: "絞り込む期間の終了時刻(Unix秒)、未指定の場合はstart+24時間"
+          schema: {type: string, example: '1713176178', default: '1711983600'}
       responses:
         '200':
           description: "成功。掃除データをjsonで返します"

--- a/api/src/go.mod
+++ b/api/src/go.mod
@@ -5,6 +5,7 @@ go 1.22.1
 require (
 	github.com/gin-gonic/gin v1.9.1
 	github.com/go-sql-driver/mysql v1.8.1
+	github.com/jinzhu/now v1.1.5
 	gorm.io/driver/mysql v1.5.6
 	gorm.io/gorm v1.25.9
 )
@@ -20,7 +21,6 @@ require (
 	github.com/go-playground/validator/v10 v10.14.0 // indirect
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
-	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.4 // indirect
 	github.com/leodido/go-urn v1.2.4 // indirect

--- a/api/src/main.go
+++ b/api/src/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"github.com/gin-gonic/gin"
 	"strconv"
+	"time"
 )
 
 type Token struct {
@@ -80,17 +81,29 @@ func getCleanDataHandler(c *gin.Context) {
 }
 
 func getQueryAboutTime(c *gin.Context) (int64, int64, error) {
+	var start_time int64
+	var end_time int64
+	var err error
+
 	start := c.Query("start")
+	if start == "" {
+		start_time = time.Now().AddDate(0, 0, -7).Unix() //startパラメータがない場合は7日前の時間を取得
+	} else {
+		start_time, err = strconv.ParseInt(start, 10, 64)
+		if err != nil {
+			return 0, 0, err
+		}
+	}
 	end := c.Query("end")
-	start_time, err := strconv.ParseInt(start, 10, 64)
-	if err != nil {
-		return 0, 0, err
+	if end == "" {
+		end_time = time.Now().Unix() //endパラメータがない場合は現在の時間を取得
+	} else {
+		end_time, err = strconv.ParseInt(end, 10, 64)
+		if err != nil {
+			return 0, 0, err
+		}
 	}
-	end_time, err := strconv.ParseInt(end, 10, 64)
-	if err != nil {
-		return 0, 0, err
-	}
-	if start_time > end_time {
+	if start_time >= end_time {
 		return 0, 0, errors.New("Invalid time range")
 	}
 	return start_time, end_time, nil

--- a/api/src/main.go
+++ b/api/src/main.go
@@ -98,7 +98,7 @@ func getQueryAboutTime(c *gin.Context) (int64, int64, error) {
 	end := c.Query("end")
 	if end == "" {
 		//endパラメータがない場合はstart_timeの24時間後を取得
-		end_time = start_time + 24*60*60
+		end_time = now.EndOfDay().Unix()
 	} else {
 		end_time, err = strconv.ParseInt(end, 10, 64)
 		if err != nil {

--- a/api/src/main.go
+++ b/api/src/main.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"github.com/gin-gonic/gin"
 	"strconv"
-	"time"
+	"github.com/jinzhu/now"
 )
 
 type Token struct {
@@ -85,11 +85,10 @@ func getQueryAboutTime(c *gin.Context) (int64, int64, error) {
 	var end_time int64
 	var err error
 
-	now := time.Now()
 	start := c.Query("start")
 	if start == "" {
 		//startパラメータがない場合は当日の0時0分0秒を取得
-		start_time = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location()).Unix()
+		start_time = now.BeginningOfDay().Unix()
 	} else {
 		start_time, err = strconv.ParseInt(start, 10, 64)
 		if err != nil {

--- a/api/src/main.go
+++ b/api/src/main.go
@@ -98,7 +98,7 @@ func getQueryAboutTime(c *gin.Context) (int64, int64, error) {
 	end := c.Query("end")
 	if end == "" {
 		//endパラメータがない場合はstart_timeの24時間後を取得
-		end_time = now.EndOfDay().Unix()
+		end_time = start_time + 24*60*60
 	} else {
 		end_time, err = strconv.ParseInt(end, 10, 64)
 		if err != nil {

--- a/api/src/main.go
+++ b/api/src/main.go
@@ -85,9 +85,11 @@ func getQueryAboutTime(c *gin.Context) (int64, int64, error) {
 	var end_time int64
 	var err error
 
+	now := time.Now()
 	start := c.Query("start")
 	if start == "" {
-		start_time = time.Now().AddDate(0, 0, -7).Unix() //startパラメータがない場合は7日前の時間を取得
+		//startパラメータがない場合は当日の0時0分0秒を取得
+		start_time = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location()).Unix()
 	} else {
 		start_time, err = strconv.ParseInt(start, 10, 64)
 		if err != nil {
@@ -96,7 +98,8 @@ func getQueryAboutTime(c *gin.Context) (int64, int64, error) {
 	}
 	end := c.Query("end")
 	if end == "" {
-		end_time = time.Now().Unix() //endパラメータがない場合は現在の時間を取得
+		//endパラメータがない場合はstart_timeの24時間後を取得
+		end_time = start_time + 24*60*60
 	} else {
 		end_time, err = strconv.ParseInt(end, 10, 64)
 		if err != nil {


### PR DESCRIPTION
This PR is to resolve #36 .  

- getQueryAboutTime()関数を編集。AddDateメソッドでを用いてstartパラメータが指定されていないときは7日前を、endパラメータが指定されていないときは現在の時刻をデフォルト値として設定するようにした。  
- AddDate(year, month, day)をAddDate(0, 0, -7)として7日前と設定している。
