### PR TITLE
Role、Location、M5stick追加用のエンドポイントの作成

### DIFF
--- a/api/api/openapi.yml
+++ b/api/api/openapi.yml
@@ -56,6 +56,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /roles:
+    post:
+      summary: "ロールの追加"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RequestRole'
+      responses:
+        '200':
+          description: "成功。追加したロールをjsonで返します"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name: {type: string, example: "Cleaning"}
+        '400':
+          description: "失敗。エラーメッセージをjsonで返します"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 components:
   schemas:
     ActivityData:
@@ -98,6 +122,10 @@ components:
       properties:
         ID: {type: integer, example: 1}
         Name: {type: string, example: "Cleaning"}
+    RequestRole:
+      type: object
+      properties:
+        name: {type: string, example: "Cleaning"}
     Location:
       type: object
       properties:

--- a/api/api/openapi.yml
+++ b/api/api/openapi.yml
@@ -64,16 +64,58 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/RequestRole'
+              $ref: '#/components/schemas/RoleData'
       responses:
         '200':
           description: "成功。追加したロールをjsonで返します"
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  name: {type: string, example: "Cleaning"}
+                $ref: '#/components/schemas/RoleData'
+        '400':
+          description: "失敗。エラーメッセージをjsonで返します"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /locations:
+    post:
+      summary: "場所の追加"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LocationData'
+      responses:
+        '200':
+          description: "成功。追加した場所をjsonで返します"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LocationData'
+        '400':
+          description: "失敗。エラーメッセージをjsonで返します"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  /m5sticks:
+    post:
+      summary: "M5Stickの追加"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/M5StickData'
+      responses:
+        '200':
+          description: "成功。追加したM5Stickをjsonで返します"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/M5StickData'
         '400':
           description: "失敗。エラーメッセージをjsonで返します"
           content:
@@ -122,15 +164,25 @@ components:
       properties:
         ID: {type: integer, example: 1}
         Name: {type: string, example: "Cleaning"}
-    RequestRole:
-      type: object
-      properties:
-        name: {type: string, example: "Cleaning"}
     Location:
       type: object
       properties:
         ID: {type: integer, example: 1}
         Name: {type: string, example: "F1"}
+    RoleData:
+      type: object
+      properties:
+        name: {type: string, example: "Cleaning"}
+    LocationData:
+      type: object
+      properties:
+        name: {type: string, example: "F1"}
+    M5StickData:
+      type: object
+      properties:
+        mac: {type: string, example: "00:00:00:00:00:00"}
+        role: {type: string, example: "Cleaning"}
+        location: {type: string, example: "F1"}
     Error:
       type: object
       properties:

--- a/api/src/db.go
+++ b/api/src/db.go
@@ -188,7 +188,7 @@ func addLocationToDB(locationName string) error {
 	return nil
 }
 
-func addM5StickToDB(mac string, roleId int, locationId int) error {
+func addM5StickToDB(mac string, roleName string, locationName string) error {
 	db, err := connectToDB()
 	if err != nil {
 		return err
@@ -203,6 +203,20 @@ func addM5StickToDB(mac string, roleId int, locationId int) error {
 	} else {
 		return errors.New("M5Stick already exists")
 	}
+	// roleNameからRoleIdを取得
+	var role Role
+	if err := db.Where("name = ?", roleName).First(&role).Error; err != nil {
+		return err
+	}
+	roleId := role.ID
+
+	// locationNameからLocationIdを取得
+	var location Location
+	if err := db.Where("name = ?", locationName).First(&location).Error; err != nil {
+		return err
+	}
+	locationId := location.ID
+
 	m5Stick := M5Stick{Mac: mac, RoleId: roleId, LocationId: locationId}
 
 	// データベースにM5Stickを追加

--- a/api/src/db.go
+++ b/api/src/db.go
@@ -155,11 +155,58 @@ func addRoleToDB(roleName string) error {
 	} else {
 		return errors.New("Role already exists")
 	}
-	// 新しいRoleを作成
 	role := Role{Name: roleName}
 
 	// データベースにRoleを追加
 	if result := db.Create(&role); result.Error != nil {
+		return result.Error
+	}
+	return nil
+}
+
+func addLocationToDB(locationName string) error {
+	db, err := connectToDB()
+	if err != nil {
+		return err
+	}
+
+	// 同じ名前のLocationがすでに存在するかを確認
+	var existingLocation Location
+	if err := db.Where("name = ?", locationName).First(&existingLocation).Error; err != nil {
+		if err != gorm.ErrRecordNotFound {
+			return err
+		}
+	} else {
+		return errors.New("Location already exists")
+	}
+	location := Location{Name: locationName}
+
+	// データベースにLocationを追加
+	if result := db.Create(&location); result.Error != nil {
+		return result.Error
+	}
+	return nil
+}
+
+func addM5StickToDB(mac string, roleId int, locationId int) error {
+	db, err := connectToDB()
+	if err != nil {
+		return err
+	}
+
+	// 同じMACアドレスのM5Stickがすでに存在するかを確認
+	var existingM5Stick M5Stick
+	if err := db.Where("mac = ?", mac).First(&existingM5Stick).Error; err != nil {
+		if err != gorm.ErrRecordNotFound {
+			return err
+		}
+	} else {
+		return errors.New("M5Stick already exists")
+	}
+	m5Stick := M5Stick{Mac: mac, RoleId: roleId, LocationId: locationId}
+
+	// データベースにM5Stickを追加
+	if result := db.Create(&m5Stick); result.Error != nil {
 		return result.Error
 	}
 	return nil

--- a/api/src/main.go
+++ b/api/src/main.go
@@ -41,8 +41,8 @@ type LocationRequestData struct {
 
 type M5StickRequestData struct {
 	Mac string `json:"mac"`
-	RoleId int `json:"role_id"`
-	LocationId int `json:"location_id"`
+	RoleName string `json:"role"`
+	LocationName string `json:"location"`
 }
 
 type UserData struct {
@@ -377,16 +377,16 @@ func addM5Stick(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	if requestData.Mac == "" || requestData.RoleId <= 0 || requestData.LocationId <= 0 {
+	if requestData.Mac == "" || requestData.RoleName == "" || requestData.LocationName == "" {
 		// パラメータが空の場合はnullを返す
 		c.JSON(http.StatusOK, nil)
 		return
 	}
 	// データベースにM5Stickを追加
-	if err := addM5StickToDB(requestData.Mac, requestData.RoleId, requestData.LocationId); err != nil {
+	if err := addM5StickToDB(requestData.Mac, requestData.RoleName, requestData.LocationName); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"mac": requestData.Mac, "role_id": requestData.RoleId, "location_id": requestData.LocationId})
+	c.JSON(http.StatusOK, gin.H{"mac": requestData.Mac, "role": requestData.RoleName, "location": requestData.LocationName})
 	return
 }

--- a/api/src/main.go
+++ b/api/src/main.go
@@ -31,6 +31,10 @@ type ActivityRequestData struct {
 	Uid string `json:"uid"`
 }
 
+type RoleRequestData struct {
+	Name string `json:"name"`
+}
+
 type UserData struct {
 	IntraName string `json:"intra_name"`
 }
@@ -56,7 +60,11 @@ func main() {
 	router.GET("/:uid", RedirectToIndexWithUID)
 	router.GET("/callback", ShowCallbackPage)
 	router.POST("/receive-uid", HandleUIDSubmission)
+
 	router.POST("/activities", addActivity)
+	router.POST("/roles", addRole)
+	// router.POST("/locations", addLocation)
+	// router.POST("/m5sticks", addM5Stick)
 
 	router.GET("/activities/cleanings", getCleanDataHandler)
 
@@ -302,5 +310,27 @@ func addActivity(c *gin.Context) {
 	// 取得したuserDataを含めてレスポンスを返す
 	c.JSON(http.StatusOK, gin.H{
 		"uid": requestData.Uid, "mac": requestData.Mac})
+	return
+}
+
+func addRole(c *gin.Context) {
+	var requestData RoleRequestData
+
+	// JSONリクエストボディを解析してrequestDataに格納
+	if err := c.BindJSON(&requestData); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if requestData.Name == "" {
+		// パラメータが空の場合はnullを返す
+		c.JSON(http.StatusOK, nil)
+		return
+	}
+	// データベースにRoleを追加
+	if err := addRoleToDB(requestData.Name); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"name": requestData.Name})
 	return
 }

--- a/api/src/main.go
+++ b/api/src/main.go
@@ -35,6 +35,16 @@ type RoleRequestData struct {
 	Name string `json:"name"`
 }
 
+type LocationRequestData struct {
+	Name string `json:"name"`
+}
+
+type M5StickRequestData struct {
+	Mac string `json:"mac"`
+	RoleId int `json:"role_id"`
+	LocationId int `json:"location_id"`
+}
+
 type UserData struct {
 	IntraName string `json:"intra_name"`
 }
@@ -63,8 +73,8 @@ func main() {
 
 	router.POST("/activities", addActivity)
 	router.POST("/roles", addRole)
-	// router.POST("/locations", addLocation)
-	// router.POST("/m5sticks", addM5Stick)
+	router.POST("/locations", addLocation)
+	router.POST("/m5sticks", addM5Stick)
 
 	router.GET("/activities/cleanings", getCleanDataHandler)
 
@@ -332,5 +342,49 @@ func addRole(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"name": requestData.Name})
+	return
+}
+
+func addLocation(c *gin.Context) {
+	var requestData LocationRequestData
+
+	// JSONリクエストボディを解析してrequestDataに格納
+	if err := c.BindJSON(&requestData); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if requestData.Name == "" {
+		// パラメータが空の場合はnullを返す
+		c.JSON(http.StatusOK, nil)
+		return
+	}
+	// データベースにLocationを追加
+	if err := addLocationToDB(requestData.Name); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"name": requestData.Name})
+	return
+}
+
+func addM5Stick(c *gin.Context) {
+	var requestData M5StickRequestData
+
+	// JSONリクエストボディを解析してrequestDataに格納
+	if err := c.BindJSON(&requestData); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if requestData.Mac == "" || requestData.RoleId <= 0 || requestData.LocationId <= 0 {
+		// パラメータが空の場合はnullを返す
+		c.JSON(http.StatusOK, nil)
+		return
+	}
+	// データベースにM5Stickを追加
+	if err := addM5StickToDB(requestData.Mac, requestData.RoleId, requestData.LocationId); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"mac": requestData.Mac, "role_id": requestData.RoleId, "location_id": requestData.LocationId})
 	return
 }

--- a/api/src/main.go
+++ b/api/src/main.go
@@ -72,16 +72,18 @@ func main() {
 	router.POST("/receive-uid", HandleUIDSubmission)
 
 	router.POST("/activities", addActivity)
-	router.POST("/roles", addRole)
-	router.POST("/locations", addLocation)
-	router.POST("/m5sticks", addM5Stick)
+	router.GET("/activities/cleanings", getCleanData)
 
-	router.GET("/activities/cleanings", getCleanDataHandler)
+	router.POST("/roles", addRole)
+
+	router.POST("/locations", addLocation)
+
+	router.POST("/m5sticks", addM5Stick)
 
 	router.Run(":8000")
 }
 
-func getCleanDataHandler(c *gin.Context) {
+func getCleanData(c *gin.Context) {
 	//start_timeとend_timeを取得
 	start_time, end_time, err := getQueryAboutTime(c)
 	if err != nil {


### PR DESCRIPTION
This PR is to resolve #12 

- 外部キー制約のため削除はできなかった。
- 削除するためには、1. 外部キー制約の一時的な無効化、2. 論理削除、3. 削除対象を参照しているものを消す の3つの方法があるが、2の論理削除が最も安全と思われる。
- 論理削除の場合、deleted_atをテーブルに追加する必要がある。