### PR TITLE
make editUser()

### DIFF
--- a/api/api/openapi.yml
+++ b/api/api/openapi.yml
@@ -9,6 +9,7 @@ paths:
   /users:
     post:
       summary: "ユーザの追加"
+      description: "intra名とuidやwalletアドレスを追加します"
       requestBody:
         required: true
         content:
@@ -30,6 +31,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+    put:
+      summary: "ユーザの編集"
+      description: "intra名に紐づくuidやwalletアドレスを更新します"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserData'
+              required:
+                - login
+      responses:
+        '200':
+          description: "成功。更新したユーザをjsonで返します"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserData'
+        '400':
+          description: "失敗。エラーメッセージをjsonで返します"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /activities:
     post:
       summary: "アクティビティの追加"
@@ -39,6 +64,9 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/ActivityData'
+              required:
+                - mac
+                - uid
       responses:
         '200':
           description: "成功。uidとmacをjsonで返します"
@@ -89,6 +117,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/RoleData'
+              required:
+                - name
       responses:
         '200':
           description: "成功。追加したロールをjsonで返します"
@@ -111,6 +141,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/LocationData'
+              required:
+                - name
       responses:
         '200':
           description: "成功。追加した場所をjsonで返します"
@@ -133,6 +165,10 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/M5StickData'
+              required:
+                - mac
+                - role
+                - location
       responses:
         '200':
           description: "成功。追加したM5Stickをjsonで返します"

--- a/api/src/db.go
+++ b/api/src/db.go
@@ -250,3 +250,23 @@ func addUserToDB(uid string, login string, wallet string) error {
 	}
 	return nil
 }
+
+//loginがすでに存在する場合uidとwalletを更新
+func editUserInDB(uid string, login string, wallet string) error {
+	db, err := connectToDB()
+	if err != nil {
+		return err
+	}
+
+	// 同じloginのUserがすでに存在するかを確認
+	var existingUser User
+	if err := db.Where("login = ?", login).First(&existingUser).Error; err != nil {
+		return err
+	}
+
+	// Userを更新
+	if result := db.Model(&existingUser).Updates(User{UID: uid, Wallet: wallet}); result.Error != nil {
+		return result.Error
+	}
+	return nil
+}


### PR DESCRIPTION
This PR is to resolve #43 .

- intra名(Login)を元にUIDやWalletアドレスを変更するエンドポイントを作成した。
- POST系のrequiredを設定し、copilotのままになっていたエラー処理を対応させた。

## テストケース
- loginでwalletを更新
```
curl -X 'PUT' 'http://localhost:8000/users' -H 'Content-Type: application/json' -d '{"login": "tanemura", "wallet": "0xE011121A5D4A4856D31D948BA10DACC4E2CA77E1"}'
```
- loginでuidを更新
```
curl -X 'PUT' 'http://localhost:8000/users' -H 'Content-Type: application/json' -d '{"login": "tanemura", "uid":"hoge"}'
```
- loginなし
```
curl -X 'PUT' 'http://localhost:8000/users' -H 'Content-Type: application/json' -d '{"login": "", "uid":"hoge"}'
```